### PR TITLE
Switch to a third-party library for RSS parsing

### DIFF
--- a/lib/helpers/rss.js
+++ b/lib/helpers/rss.js
@@ -9,41 +9,34 @@
 // See LICENSE for details
 "use strict";
 
-const Http = require('./http');
-const Xml = require('./xml');
+const FeedParser = require('feedparser');
 
-function findPicture(pictureList) {
-    if (!pictureList)
-        return undefined;
-    return pictureList[pictureList.length-1].$.url;
-}
+const Http = require('./http');
 
 module.exports = {
     get(url, options) {
-        return Http.get(url, options).then((response) => Xml.parseString(response))
-        .then((parsed) => {
-            const toEmit = [];
-            if (parsed.feed) {
-                for (let entry of parsed.feed.entry) {
-                    let updated_time = new Date(entry.updated[0]);
-                    let title = entry.title[0]._ || entry.title[0];
-                    let link = entry.link[0].$.href;
-                    toEmit.push({ title, link, updated_time });
-                }
-            } else {
-                for (let entry of parsed.rss.channel[0].item) {
-                    let updated_time = new Date(entry.pubDate[0]);
-                    let title = entry.title[0]._ || entry.title[0];
-                    let link = entry.link ? (entry.link[0]._ || entry.link[0]) : null;
-                    let description = entry.description[0] ? (entry.description[0]._ || entry.description[0]) : '';
-                    let picture_url = undefined;
-                    if (entry['media:group'])
-                        picture_url = findPicture(entry['media:group'][0]['media:content']);
+        return Http.getStream(url, options).then((stream) => {
+            return new Promise((resolve, reject) => {
+                const parser = new FeedParser({ feedurl: url });
+                parser.on('error', reject);
 
-                    toEmit.push({ title, link, updated_time, description, picture_url });
-                }
-            }
-
+                const toEmit = [];
+                parser.on('data', (entry) => {
+                    toEmit.push({
+                        guid: entry.guid,
+                        title: entry.title,
+                        description: entry.description,
+                        link: entry.link,
+                        author: entry.author,
+                        updated_time: new Date(entry.date),
+                        picture_url: entry.image ? entry.image.url : null,
+                        categories: entry.categories
+                    });
+                });
+                parser.on('end', () => resolve(toEmit));
+                stream.pipe(parser);
+            });
+        }).then((toEmit) => {
             toEmit.sort((a, b) => (+b.updated_time) - (+a.updated_time));
 
             // At some point, we messed up, and mixed "updated" and "updated_time" as

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   ],
   "main": "index.js",
   "dependencies": {
+    "feedparser": "^2.2.9",
     "ip": "~1.1.0",
     "oauth": "~0.9.14",
     "p-finally": "^1.0.0",

--- a/test/test_rss.js
+++ b/test/test_rss.js
@@ -40,10 +40,42 @@ function testAtom() {
     });
 }
 
+function testXkcdWhatIf() {
+    // Xkcd's what if requires handling namespaces correctly
+    return RSS.get('https://what-if.xkcd.com/feed.atom').then((items) => {
+        items.forEach((item, i) => {
+            assert(item.updated_time instanceof Date);
+            assert(item.updated instanceof Date);
+            if (i > 0)
+                assert(+item.updated_time <= +items[i-1].updated_time);
+            assert(item.title);
+            assert(item.link.startsWith('https://what-if.xkcd.com'));
+        });
+    });
+}
+
+function testWashingtonPost() {
+    // Washington Post requires correct handling of pictures
+    return RSS.get('http://feeds.washingtonpost.com/rss/politics').then((items) => {
+        items.forEach((item, i) => {
+            assert(item.updated_time instanceof Date);
+            assert(item.updated instanceof Date);
+            if (i > 0)
+                assert(+item.updated_time <= +items[i-1].updated_time);
+            assert(item.title);
+            assert(item.description);
+            assert(item.picture_url);
+            assert(item.link.startsWith('https://www.washingtonpost.com/'));
+        });
+    });
+}
+
 function main() {
     return Promise.all([
         testRSS1(),
-        testAtom()
+        testAtom(),
+        testXkcdWhatIf(),
+        testWashingtonPost()
     ]);
 }
 module.exports = main;

--- a/yarn.lock
+++ b/yarn.lock
@@ -92,6 +92,10 @@ acorn@^5.0.3, acorn@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
 
+addressparser@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/addressparser/-/addressparser-1.0.1.tgz#47afbe1a2a9262191db6838e4fd1d39b40821746"
+
 adt@~0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/adt/-/adt-0.7.2.tgz#824bb725fe3632c8c35ec24985df610f97d98244"
@@ -179,6 +183,10 @@ arr-flatten@^1.1.0:
 arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
+
+array-indexofobject@~0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/array-indexofobject/-/array-indexofobject-0.0.1.tgz#aaa128e62c9b3c358094568c219ff64fe489d42a"
 
 array-union@^1.0.1:
   version "1.0.2"
@@ -457,7 +465,7 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
-core-util-is@1.0.2:
+core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
@@ -768,6 +776,20 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
+feedparser@^2.2.9:
+  version "2.2.9"
+  resolved "https://registry.yarnpkg.com/feedparser/-/feedparser-2.2.9.tgz#9138197dafdae05fcadde0036beeaf6066c2c5e9"
+  dependencies:
+    addressparser "^1.0.1"
+    array-indexofobject "~0.0.1"
+    lodash.assign "^4.2.0"
+    lodash.get "^4.4.2"
+    lodash.has "^4.5.2"
+    lodash.uniq "^4.5.0"
+    mri "^1.1.0"
+    readable-stream "^2.2.2"
+    sax "^1.2.4"
+
 figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
@@ -1000,7 +1022,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2:
+inherits@2, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -1172,7 +1194,7 @@ is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
-isarray@1.0.0:
+isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
@@ -1358,6 +1380,22 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lodash.assign@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
+
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
+lodash.has@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/lodash.has/-/lodash.has-4.5.2.tgz#d19f4dc1095058cccbe2b0cdf4ee0fe4aa37c862"
+
+lodash.uniq@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
+
 lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
@@ -1477,6 +1515,10 @@ mkdirp@^0.5.0, mkdirp@^0.5.1:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
+
+mri@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.1.tgz#85aa26d3daeeeedf80dc5984af95cc5ca5cad9f1"
 
 ms@2.0.0:
   version "2.0.0"
@@ -1740,6 +1782,10 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
 
+process-nextick-args@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
+
 progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
@@ -1774,6 +1820,18 @@ read-pkg@^1.0.0:
     load-json-file "^1.0.0"
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
+
+readable-stream@^2.2.2:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
 
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
@@ -1881,7 +1939,7 @@ rxjs@^5.5.2:
   dependencies:
     symbol-observable "1.0.1"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.1:
+safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
 
@@ -1895,7 +1953,7 @@ safe-regex@^1.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
-sax@>=0.6.0:
+sax@>=0.6.0, sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
@@ -2093,6 +2151,12 @@ string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  dependencies:
+    safe-buffer "~5.1.0"
+
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
@@ -2279,6 +2343,10 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.0.tgz#14716bf03fdfefd03040aef58d8b4b85f3a7c544"
   dependencies:
     kind-of "^6.0.2"
+
+util-deprecate@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
 uuid@^3.1.0:
   version "3.2.1"


### PR DESCRIPTION
We discussed this a couple times but never got around to do it.
I decided it was time to fix it after finding too many bugs
with the existing RSS code while testing thingpedia-common-devices
(in the parts that are not shown by the formatted output)