### PR TITLE
BaseDevice: provide sensible defaults for uniqueId, name and description

### DIFF
--- a/lib/base_device.js
+++ b/lib/base_device.js
@@ -30,19 +30,35 @@ module.exports = class BaseDevice extends events.EventEmitter {
     constructor(engine, state) {
         super();
         this._engine = engine;
+        this.state = state;
 
         // Set this to a device specific ID plus something unique
         // (eg "mydevice-aa-bb-cc-dd-ee-ff") so that no other device
         // can possibly have the same ID
-        // If you leave it undefined, DeviceDatabase will pick for you
-        this.uniqueId = undefined;
+        // If you leave it unset, DeviceDatabase will pick for you
+
+        // provide default uniqueId for config.none() devices
+        const ast = this.metadata;
+        const params = Object.keys(ast.params);
+        const isNoneFactory = ast.auth.type === 'none' && params.length === 0;
+        const isNoneAuth = ast.auth.type === 'none';
+        if (isNoneFactory)
+            this.uniqueId = this.kind;
+        else if (isNoneAuth)
+            this.uniqueId = this.kind + '-' + params.map((k) => (k + ':' + state[k])).join('-');
+        else
+            this.uniqueId = undefined; // let DeviceDatabase pick something
+
+        // provide default name and description
+        // NOTE: these are not getters, because the subclass can override
+        // them and mutate them as it wishes
+        this.name = ast.name;
+        this.description = ast.description;
 
         // Set these to protocol/discovery specific IDs (such as
         // "bluetooth/aa-bb-cc-dd-ee-ff") so that it is unlikely that
         // another device has the same ID
         this.descriptors = [];
-
-        this.state = state;
 
         // Set to true if this device should not be stored in the devicedb
         // but only kept in memory (ie, its lifetime is managed by some
@@ -54,6 +70,9 @@ module.exports = class BaseDevice extends events.EventEmitter {
 
     get kind() {
         return this.state.kind;
+    }
+    get metadata() {
+        return this.constructor.metadata;
     }
 
     stateChanged() {

--- a/test/index.js
+++ b/test/index.js
@@ -6,22 +6,20 @@ require('..');
 process.on('unhandledRejection', (up) => { throw up; });
 process.env.TEST_MODE = '1';
 
-function seq(array) {
-    return (function loop(i) {
-        if (i === array.length)
-            return Promise.resolve();
-        else
-            return Promise.resolve(array[i]()).then(() => loop(i+1));
-    })(0);
+async function seq(array) {
+    for (let el of array) {
+        console.log(`Running tests for ${el}`);
+        await require(el)();
+    }
 }
 
 seq([
-    require('./test_version'),
-    require('./test_class'),
-    require('./test_object_set'),
-    require('./test_http'),
-    require('./test_rss'),
-    require('./test_polling'),
-    require('./test_refcounted'),
-    require('./test_content')
+    ('./test_version'),
+    ('./test_class'),
+    ('./test_object_set'),
+    ('./test_http'),
+    ('./test_rss'),
+    ('./test_polling'),
+    ('./test_refcounted'),
+    ('./test_content')
 ]);

--- a/test/test_class.js
+++ b/test/test_class.js
@@ -13,24 +13,78 @@ const assert = require('assert');
 
 const BaseDevice = require('../lib/base_device');
 
-class MyDevice extends BaseDevice {
+class MyDevice1 extends BaseDevice {
     constructor(engine, state) {
         super(engine, state);
 
         assert(Array.isArray(this.descriptors));
-        assert.equal(this._engine, engine);
-        assert.equal(this.state, state);
+        assert.strictEqual(this._engine, engine);
+        assert.strictEqual(this.state, state);
+        assert.strictEqual(this.uniqueId, 'com.foo');
+        assert.strictEqual(this.name, 'My Device 1');
+        assert.strictEqual(this.description, 'This is the first device');
     }
 }
-MyDevice.metadata = {
+MyDevice1.metadata = {
     types: ['fooable'],
     child_types: [],
-    category: 'data'
+    category: 'data',
+    params: {},
+    name: 'My Device 1',
+    description: 'This is the first device',
+
+    auth: { type: 'none' }
 };
 
-function testBasic(d, e) {
+class MyDevice2 extends BaseDevice {
+    constructor(engine, state) {
+        super(engine, state);
+
+        assert(Array.isArray(this.descriptors));
+        assert.strictEqual(this._engine, engine);
+        assert.strictEqual(this.state, state);
+        assert.strictEqual(this.uniqueId, 'com.bar-url:http://www.google.com');
+        assert.strictEqual(this.name, 'My Device 2');
+        assert.strictEqual(this.description, 'This is the second device');
+    }
+}
+MyDevice2.metadata = {
+    types: [],
+    child_types: [],
+    category: 'data',
+    params: {
+        url: ['url', 'URL'],
+    },
+    name: 'My Device 2',
+    description: 'This is the second device',
+
+    auth: { type: 'none' }
+};
+
+class MyDevice3 extends BaseDevice {
+    constructor(engine, state) {
+        super(engine, state);
+
+        assert(Array.isArray(this.descriptors));
+        assert.strictEqual(this._engine, engine);
+        assert.strictEqual(this.state, state);
+        assert.strictEqual(this.uniqueId, undefined);
+        assert.strictEqual(this.name, undefined);
+        assert.strictEqual(this.description, undefined);
+    }
+}
+MyDevice3.metadata = {
+    types: [],
+    child_types: [],
+    category: 'data',
+    params: {},
+
+    auth: { type: 'oauth2' }
+};
+
+function testBasic(d, e, k) {
     assert.strictEqual(d.engine, e);
-    assert.strictEqual(d.kind, 'com.foo');
+    assert.strictEqual(d.kind, k);
     assert.strictEqual(d.ownerTier, 'global');
 }
 
@@ -61,20 +115,31 @@ function testChangeState(d) {
 }
 
 async function main() {
-    var e = {};
+    const e = {};
 
     const state = { kind: 'com.foo' };
-    var d = new MyDevice(e, state);
-    assert.strictEqual(d.state, state);
-    assert.strictEqual(d.serialize(), state);
+    const d1 = new MyDevice1(e, state);
+    assert.strictEqual(d1.state, state);
+    assert.strictEqual(d1.serialize(), state);
 
-    testBasic(d, e);
-    testHasKind(d);
+    testBasic(d1, e, 'com.foo');
+    testHasKind(d1);
 
-    await d.checkAvailable();
+    await d1.checkAvailable();
 
-    testStateChanged(d);
-    testChangeState(d);
+    testStateChanged(d1);
+    testChangeState(d1);
+
+    const d2 = new MyDevice2(e, {
+        kind: 'com.bar',
+        url: 'http://www.google.com'
+    });
+    testBasic(d2, e, 'com.bar');
+
+    const d3 = new MyDevice3(e, {
+        kind: 'com.baz'
+    });
+    testBasic(d3, e, 'com.baz');
 }
 module.exports = main;
 if (!module.parent)


### PR DESCRIPTION
So that some devices can avoid writing constructors