### PR TITLE
oauth2: make extra data returned by /token endpoint available

### DIFF
--- a/lib/helpers/oauth2.js
+++ b/lib/helpers/oauth2.js
@@ -85,14 +85,14 @@ module.exports = function OAuth2Helper(params) {
                 redirect_uri: redirect_uri
             };
             return new Promise((resolve, reject) => {
-                auth.getOAuthAccessToken(code, options, (err, accessToken, refreshToken) => {
+                auth.getOAuthAccessToken(code, options, (err, accessToken, refreshToken, extraData) => {
                     if (err)
                         reject(err);
                     else
-                        resolve([accessToken, refreshToken]);
+                        resolve([accessToken, refreshToken, extraData]);
                 });
-            }).then(([accessToken, refreshToken]) => {
-                return params.callback(engine, accessToken, refreshToken);
+            }).then(([accessToken, refreshToken, extraData]) => {
+                return params.callback(engine, accessToken, refreshToken, extraData);
             }).catch((e) => {
                 console.error('Error obtaining access token', e);
                 if (!e.message)


### PR DESCRIPTION
Imgur returns the username there, and nowhere else in their API