### PR TITLE
helpers/http: add a debug option to control error dumps

### DIFF
--- a/lib/helpers/http.js
+++ b/lib/helpers/http.js
@@ -57,6 +57,8 @@ function httpRequestStream(url, method, data, options, uploadStream, downloadStr
         parsed.headers['User-Agent'] = 'Thingpedia/1.0.0 nodejs/' + process.version;
     if (options.extraHeaders)
         Object.assign(parsed.headers, options.extraHeaders);
+    if (options.debug === undefined)
+        options.debug = true;
 
     var ignoreErrors = !!options.ignoreErrors;
 
@@ -92,7 +94,7 @@ function httpRequestStream(url, method, data, options, uploadStream, downloadStr
                     data += chunk;
                 });
                 res.on('end', () => {
-                    if (res.statusCode !== 301 && res.statusCode !== 302 && res.statusCode !== 303)
+                    if (options.debug && (res.statusCode !== 301 && res.statusCode !== 302 && res.statusCode !== 303))
                         console.log('HTTP request failed: ' + data);
 
                     var error = new Error('Unexpected HTTP error ' + res.statusCode);


### PR DESCRIPTION
Allow silencing the dump of failed responses on stdout

This is useful for tests, which generate a bunch of expected HTTP
errors.