### PR TITLE
Fix bug in resubmitting POST requests after redirect

### DIFF
--- a/lib/helpers/http.js
+++ b/lib/helpers/http.js
@@ -88,7 +88,7 @@ function httpRequestStream(url, method, data, options, uploadStream, downloadStr
                 return;
             }
             if (!ignoreErrors && res.statusCode >= 300) {
-                var data = '';
+                let data = '';
                 res.setEncoding('utf8');
                 res.on('data', (chunk) => {
                     data += chunk;


### PR DESCRIPTION
HTTP spec says that after a 301, 302 or 307 redirect, POST requests
should be sent with the original body.
Instead, we were sending undefined.

lgtm.com caught this bug by noticing that the variable data we used
was not the one in the outer scope (as we thought) but another
unrelated variable with the same name, that was hoisted earlier.
Replacing "var" with "let" removes the hoisting and fixes the bug.